### PR TITLE
Android Emulator Description

### DIFF
--- a/docs/onboarding/setup/10_Dotto.md
+++ b/docs/onboarding/setup/10_Dotto.md
@@ -45,20 +45,10 @@ Firebase の情報をセットアップします。
 以下のコマンドを実行すると、証明書のフィンガープリントが表示される。
 
 ```
-% keytool -genkey -v -alias dotto -keyalg RSA -keysize 2048 -validity 365 -keypass dottoandroid -keystore ~/.android/debug.keystore -storepass android
-% keytool -list -v -alias dotto -keystore ~/.android/debug.keystore -storepass android
+% keytool -list -v -alias androiddebugkey -keystore ~/.android/debug.keystore -storepass android
 ```
 
 [Firebase](https://console.firebase.google.com/u/0/project/swift2023groupc/settings/general/android:jp.ac.fun.dotto?hl=ja)にアクセスして、表示された SHA-1 のフィンガープリントを登録する。
-
-Visual Studio Code を開いて、`android/key.properties`を作成し、以下の内容を記述する。
-
-```
-keyAlias=dotto
-keyPassword=dottoandroid
-storeFile=~/.android/debug.keystore
-storePassword=android
-```
 
 ## [Windows] Android Emulator で起動する
 
@@ -73,17 +63,7 @@ Ex. `C:\Program Files\Android\Android Studio\jbr\bin`
 以下のコマンドを実行すると、証明書のフィンガープリントが表示される。
 
 ```
-> keytool -genkey -v -alias dotto -keyalg RSA -keysize 2048 -validity 365 -keypass dottoandroid -keystore ~\.android\debug.keystore -storepass android
-> keytool -list -v -alias dotto -keystore ~\.android\debug.keystore -storepass android
+> keytool -list -v -alias androiddebugkey -keystore ~\.android\debug.keystore -storepass android
 ```
 
 [Firebase](https://console.firebase.google.com/u/0/project/swift2023groupc/settings/general/android:jp.ac.fun.dotto?hl=ja)にアクセスして、表示された SHA-1 のフィンガープリントを登録する。
-
-Visual Studio Code を開いて、`.\android\key.properties`を作成し、以下の内容を記述する。
-
-```
-keyAlias=dotto
-keyPassword=dottoandroid
-storeFile=~\.android\debug.keystore
-storePassword=android
-```

--- a/docs/onboarding/setup/10_Dotto.md
+++ b/docs/onboarding/setup/10_Dotto.md
@@ -40,6 +40,26 @@ Firebase の情報をセットアップします。
 % make run
 ```
 
+## [macOS] Android Emulator で起動する
+
+以下のコマンドを実行すると、証明書のフィンガープリントが表示される。
+
+```
+% keytool -genkey -v -alias dotto -keyalg RSA -keysize 2048 -validity 365 -keypass dottoandroid -keystore ~/.android/debug.keystore -storepass android
+% keytool -list -v -alias dotto -keystore ~/.android/debug.keystore -storepass android
+```
+
+[Firebase](https://console.firebase.google.com/u/0/project/swift2023groupc/settings/general/android:jp.ac.fun.dotto?hl=ja)にアクセスして、表示された SHA-1 のフィンガープリントを登録する。
+
+Visual Studio Code を開いて、`android/key.properties`を作成し、以下の内容を記述する。
+
+```
+keyAlias=dotto
+keyPassword=dottoandroid
+storeFile=~/.android/debug.keystore
+storePassword=android
+```
+
 ## [Windows] Android Emulator で起動する
 
 Android Studio で使用されている Java があるフォルダのパスをコピーする。
@@ -50,19 +70,20 @@ Ex. `C:\Program Files\Android\Android Studio\jbr\bin`
 > set PATH=<コピーしたパスをペースト>;%PATH%
 ```
 
-以下のコマンドを実行して進めると、証明書のフィンガープリントが表示される。
+以下のコマンドを実行すると、証明書のフィンガープリントが表示される。
 
 ```
-> keytool -list -v -keystore ".android\debug.keystore" -alias androiddebugkey -storepass android -keypass android
+> keytool -genkey -v -alias dotto -keyalg RSA -keysize 2048 -validity 365 -keypass dottoandroid -keystore ~\.android\debug.keystore -storepass android
+> keytool -list -v -alias dotto -keystore ~\.android\debug.keystore -storepass android
 ```
 
-[Firebase](https://console.firebase.google.com/u/0/project/swift2023groupc/settings/general/android:jp.ac.fun.dotto?hl=ja)にアクセスして、表示された SHA-256 のフィンガープリントを登録する。
+[Firebase](https://console.firebase.google.com/u/0/project/swift2023groupc/settings/general/android:jp.ac.fun.dotto?hl=ja)にアクセスして、表示された SHA-1 のフィンガープリントを登録する。
 
-Visual Studio Code を開いて、`android/key.properties`を作成し、以下の内容を記述する。
+Visual Studio Code を開いて、`.\android\key.properties`を作成し、以下の内容を記述する。
 
 ```
+keyAlias=dotto
+keyPassword=dottoandroid
+storeFile=~\.android\debug.keystore
 storePassword=android
-keyPassword=android
-keyAlias=key
-storeFile=.android\debug.keystore
 ```


### PR DESCRIPTION
# 概要

- Android Emulatorでの起動方法を修正

# 関連する issue

- #

# 確認方法・見てほしいところ

1.

# コメント

- デバッグ時に`./android/key.properties`はいらない、`~/.android/debug.keystore`内の`alias=androiddebugkey`を自動で取ってくる
- リリース時に`./android/key.properties`を見る
  - storeFileは、`./android/app/`からの相対パス
  - リリース用のキーストアは @tigertora7571 が持ってるらしい
  - フィンガープリントはGoogle Play Consoleからも確認可能
```
keyAlias=AndroidReleaseKey
keyPassword=android
storeFile=key.jks
storePassword=android
```
