### PR TITLE
KamokuSearch: テキストフィールドに×ボタンを作成

### DIFF
--- a/lib/feature/kamoku_search/widget/kamoku_search_box.dart
+++ b/lib/feature/kamoku_search/widget/kamoku_search_box.dart
@@ -7,8 +7,7 @@ class KamokuSearchBox extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final kamokuSearchController = ref.watch(kamokuSearchControllerProvider);
-    final kamokuSearchControllerNotifier =
-        ref.watch(kamokuSearchControllerProvider.notifier);
+    final kamokuSearchControllerNotifier = ref.watch(kamokuSearchControllerProvider.notifier);
     return TextField(
       controller: kamokuSearchController.textEditingController,
       focusNode: kamokuSearchController.searchBoxFocusNode,
@@ -16,8 +15,18 @@ class KamokuSearchBox extends ConsumerWidget {
         fontSize: 18,
         color: Colors.black,
       ),
-      decoration: const InputDecoration(
+      decoration: InputDecoration(
         hintText: '科目名を検索',
+        suffixIcon: kamokuSearchController.textEditingController.text.isNotEmpty
+            ? IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () {
+                  kamokuSearchController.textEditingController.clear();
+                  kamokuSearchControllerNotifier.setSearchWord('');
+                  kamokuSearchController.searchBoxFocusNode.unfocus();
+                },
+              )
+            : null,
       ),
       onChanged: (text) {
         kamokuSearchControllerNotifier.setSearchWord(text);


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要
科目検索の検索バーの横に×ボタンを追加実装
<!--1行程度で完結に-->

# やったこと
TextFieldに×ボタンの実装を追加
<!--詳細はネストして記述-->
<!--完了したもののみチェックを入れる-->

- [ ]

# 関連する Issue

- Close #

# 確認したこと
科目検索のファイルの確認
×ボタンの配置位置の確認・実装
<!--CIワークフローで確認できること以外で確認したこと-->
<!--完了したもののみチェックを入れる-->

- [ ]

# UI 差分

|           Before           |
<img width="320" alt="スクリーンショット 2025-07-09 12 05 17" src="https://github.com/user-attachments/assets/ecf68a3f-3541-4cec-8eb9-029b4d4866f9" />
| <img src="" width="200" /> 
|           After　　　   |
<img width="320" alt="スクリーンショット 2025-07-09 12 05 30" src="https://github.com/user-attachments/assets/73a8a62f-07de-405a-962b-19b383a766c5" />
| <img src="" width="200" /> |

# コメント
確認お願いします
-

# メモ

-

<!-- I want to review in Japanese. -->
